### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 15.7.2

### DIFF
--- a/SentimentAnalysisServiceAcceptanceTests/SentimentAnalysisServiceAcceptanceTests.csproj
+++ b/SentimentAnalysisServiceAcceptanceTests/SentimentAnalysisServiceAcceptanceTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/SentimentAnalysisServiceTests/SentimentAnalysisServiceTests.csproj
+++ b/SentimentAnalysisServiceTests/SentimentAnalysisServiceTests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `15.7.2` from `15.7.0`
`Microsoft.NET.Test.Sdk 15.7.2` was published at `2018-05-16T07:37:07Z`, 1 month ago

2 project updates:
Updated `SentimentAnalysisServiceTests/SentimentAnalysisServiceTests.csproj` to `Microsoft.NET.Test.Sdk` `15.7.2` from `15.7.0`
Updated `SentimentAnalysisServiceAcceptanceTests/SentimentAnalysisServiceAcceptanceTests.csproj` to `Microsoft.NET.Test.Sdk` `15.7.2` from `15.7.0`

This is an automated update. Merge only if it passes tests

[Microsoft.NET.Test.Sdk 15.7.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/15.7.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
